### PR TITLE
Add 5 open source SEO tools (robots.txt, IndexNow, Schema, AI Visibility, MCP list)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,21 @@ For SEO masters, maybe those amount of website traffic is too ordinary. However,
 [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker)
 > Open-source, local-first AI search visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+[robotstxt-ai](https://github.com/sharozdawa/robotstxt-ai)
+> Open-source visual robots.txt manager for AI crawlers. Toggle GPTBot, ClaudeBot, PerplexityBot, and 20+ AI bots with one click.
+
+[indexnow-mcp](https://github.com/sharozdawa/indexnow-mcp)
+> Open-source MCP server for instant URL indexing via IndexNow (Bing, Yandex, Naver, Seznam) and Google Indexing API.
+
+[schema-gen](https://github.com/sharozdawa/schema-gen)
+> Open-source Schema.org JSON-LD markup generator with 12 types (Person, Product, FAQ, Article, Organization, HowTo, etc.).
+
+[ai-visibility](https://github.com/sharozdawa/ai-visibility)
+> Open-source tool to track brand visibility across ChatGPT, Perplexity, Claude, and Gemini. Visibility scores, sentiment analysis, competitor detection.
+
+[awesome-seo-mcp-servers](https://github.com/sharozdawa/awesome-seo-mcp-servers)
+> Curated list of SEO MCP servers, agent skills, and open source SEO tools for AI-powered development.
+
 ## Chrome Plugins
 
 [SimilarWeb](https://chrome.google.com/webstore/detail/similarweb-traffic-rank-w/hoklmmgfnpapgjgcpechhaamimifchmp)


### PR DESCRIPTION
Adding 5 open source SEO tools to the Tools section in alphabetical order:

- **[AI Visibility](https://github.com/sharozdawa/ai-visibility)** - Track brand visibility across ChatGPT, Perplexity, Claude, and Gemini. Web app + MCP server.
- **[Awesome SEO MCP Servers](https://github.com/sharozdawa/awesome-seo-mcp-servers)** - Curated list of SEO MCP servers, agent skills, and tools.
- **[IndexNow MCP](https://github.com/sharozdawa/indexnow-mcp)** - Instant URL indexing via IndexNow and Google Indexing API. MCP server.
- **[Robots.txt AI](https://github.com/sharozdawa/robotstxt-ai)** - Visual robots.txt manager for AI crawlers with 20+ bots. Web app + MCP server.
- **[Schema Gen](https://github.com/sharozdawa/schema-gen)** - Schema.org JSON-LD markup generator supporting 12 types. Web app + MCP server.

All tools are open source and available at github.com/sharozdawa.