### PR TITLE
Add content-optimizer: Open source Surfer SEO alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ For SEO masters, maybe those amount of website traffic is too ordinary. However,
 [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker)
 > Open-source, local-first AI search visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+[Content Optimizer](https://github.com/sharozdawa/content-optimizer)
+> Open source alternative to Surfer SEO. SERP-based content scoring with 7 categories (word count, keywords, headings, readability, entities, depth, technical). Web app + MCP server.
+
 ## Chrome Plugins
 
 [SimilarWeb](https://chrome.google.com/webstore/detail/similarweb-traffic-rank-w/hoklmmgfnpapgjgcpechhaamimifchmp)


### PR DESCRIPTION
Open source Surfer SEO alternative with SERP-based content scoring. GitHub: https://github.com/sharozdawa/content-optimizer | MIT