### PR TITLE
Add toprank to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ For SEO masters, maybe those amount of website traffic is too ordinary. However,
 [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker)
 > Open-source, local-first AI search visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+[toprank](https://github.com/nowork-studio/toprank)
+> Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic and wasted ad spend, rewrites meta tags, generates JSON-LD schema markup, and ships fixes to WordPress, Strapi, Contentful, or Ghost sites.
+
 ## Chrome Plugins
 
 [SimilarWeb](https://chrome.google.com/webstore/detail/similarweb-traffic-rank-w/hoklmmgfnpapgjgcpechhaamimifchmp)


### PR DESCRIPTION
Adds **toprank** to the Tools section.

toprank is an open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. It connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic and wasted ad spend, then applies fixes directly — rewriting meta tags, generating JSON-LD schema markup, and pushing content changes through CMS connectors (WordPress, Strapi, Contentful, Ghost).

- Source: https://github.com/nowork-studio/toprank
- License: MIT
- 100+ stars, actively maintained with CHANGELOG, unit tests, and LLM-judge eval tests