### PR TITLE
Add TinyTools to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ For SEO masters, maybe those amount of website traffic is too ordinary. However,
 [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker)
 > Open-source, local-first AI search visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards.
 
+[TinyTools](https://tinytools-smoky.vercel.app/)
+> Free browser-based SEO utilities, no signup. Includes SEO meta tag generator, AI robots.txt generator (handles GPTBot/ClaudeBot/etc.), AI content disclosure generator (EU AI Act compliant), favicon generator, and OG image generator. Open source, runs entirely client-side.
+
 ## Chrome Plugins
 
 [SimilarWeb](https://chrome.google.com/webstore/detail/similarweb-traffic-rank-w/hoklmmgfnpapgjgcpechhaamimifchmp)


### PR DESCRIPTION
Adding **TinyTools** to the Tools section.

**Live:** https://tinytools-smoky.vercel.app/

TinyTools is a free, no-signup, browser-based collection of single-purpose web utilities. The SEO-relevant ones:
- **SEO meta tag generator** - title, description, canonical, Open Graph, Twitter Card markup in one go
- **AI robots.txt generator** - generates robots.txt with explicit rules for AI crawlers (GPTBot, ClaudeBot, PerplexityBot, etc.)
- **AI content disclosure generator** - EU AI Act compliant disclosure markup
- **OG image generator** - on-the-fly Open Graph images
- **Favicon generator**

All run client-side, no accounts, no API keys, open source. Matched the list's existing format. Thanks for maintaining this!